### PR TITLE
Parse channel correctly on DDWRT SVN 21061

### DIFF
--- a/nodes/ddwrt.py
+++ b/nodes/ddwrt.py
@@ -99,7 +99,7 @@ class WifiAP:
     for row in reader:
       essid = row[0]
       macattr = row[2]
-      channel = int(row[3])
+      channel = int(row[3].split(' ')[0])
       rssi = int(row[4])
       noise = int(row[5])
       beacon = int(row[6])


### PR DESCRIPTION
Using router: TPLINK TL-WDR3600 v1

The channel string I get in this DDWRT version and router look like "1 (2412 kHz)" instead of just "1". This change adds support for that kind of channel format and is also backwards compatible with channels like "1".
