### PR TITLE
[wifi_ddwrt] fix typo

### DIFF
--- a/scripts/analysis
+++ b/scripts/analysis
@@ -39,8 +39,9 @@ MAX_RSSI = 100
 
 import rospy
 from wifi_ddwrt.msg import *
-from pr2_msgs import AccessPoint
+from pr2_msgs.msg import AccessPoint
 
+import array
 import math
 import tf
 from geometry_msgs.msg import *
@@ -91,8 +92,10 @@ class WifiAnalysis:
 
       self.map_res = resp.map.info.resolution
 
+      data = array.array('b', resp.map.data).tostring()
+
       # Convert map to greyscale image
-      self.im = Image.frombuffer('L', size, resp.map.data, "raw", 'L', 0, 1)
+      self.im = Image.frombuffer('L', size, data, "raw", 'L', 0, 1)
       remap = {0:255, 100: 0, 255:128}
       self.im = self.im.point(lambda x: remap.get(x, 0))
 
@@ -141,10 +144,10 @@ class WifiAnalysis:
       print "Got an exception that should never happen"
       return
 
-    if not self.aps.has_key(str(ap.macattr)):
-      self.aps[str(ap.macattr)] = ("ap" + str(len(self.aps) + 1), (20, 30, 0))
+    if not self.aps.has_key(str(ap.macaddr)):
+      self.aps[str(ap.macaddr)] = ("ap" + str(len(self.aps) + 1), (20, 30, 0))
 
-    self.positions.append((str(ap.macattr), trans, ap.signal))
+    self.positions.append((str(ap.macaddr), trans, ap.signal))
 
     signal_quality = (MAX_RSSI - -1.0 * ap.signal) / (MAX_RSSI - MIN_RSSI)
     radius = 0.1
@@ -177,9 +180,9 @@ class WifiAnalysis:
       marker.scale.y = radius
       marker.scale.z = z_scale
       marker.color.a = 1.0
-      marker.color.r = aps[str(ap.macattr)][1][0]
-      marker.color.g = aps[str(ap.macattr)][1][1]
-      marker.color.b = aps[str(ap.macattr)][1][2]
+      marker.color.r = aps[str(ap.macaddr)][1][0]
+      marker.color.g = aps[str(ap.macaddr)][1][1]
+      marker.color.b = aps[str(ap.macaddr)][1][2]
       self.vis_pub.publish(marker)
 
       angles = tf.transformations.euler_from_quaternion(rot)

--- a/scripts/monitor
+++ b/scripts/monitor
@@ -45,7 +45,7 @@ DISPLAY_HEIGHT = 1.6
 
 import rospy
 from wifi_ddwrt.msg import *
-from pr2_msgs import AccessPoint
+from pr2_msgs.msg import AccessPoint
 
 import math
 import tf
@@ -72,8 +72,8 @@ class WifiMonitor:
     self.vis_pub = rospy.Publisher('visualization_marker', Marker)
 
   def ap_cb(self, ap):
-    if not self.aps.has_key(str(ap.macattr)):
-      self.aps[str(ap.macattr)] = ("ap" + str(len(self.aps) + 1), (20, 30, 0))
+    if not self.aps.has_key(str(ap.macaddr)):
+      self.aps[str(ap.macaddr)] = ("ap" + str(len(self.aps) + 1), (20, 30, 0))
 
     signal_quality = (MAX_RSSI - -1.0 * ap.signal) / (MAX_RSSI - MIN_RSSI)
     radius = SIGNAL_BAR_RADIUS
@@ -119,9 +119,9 @@ class WifiMonitor:
       marker.scale.y = radius
       marker.scale.z = z_scale
       marker.color.a = 1.0
-      marker.color.r = aps[str(ap.macattr)][1][0]
-      marker.color.g = aps[str(ap.macattr)][1][1]
-      marker.color.b = aps[str(ap.macattr)][1][2]
+      marker.color.r = aps[str(ap.macaddr)][1][0]
+      marker.color.g = aps[str(ap.macaddr)][1][1]
+      marker.color.b = aps[str(ap.macaddr)][1][2]
       self.vis_pub.publish(marker)
 
       x += step_size


### PR DESCRIPTION
This fix includes:
- add missing `.msg` on import module
- use array module to clarify variable `data` as bytearray
- fix typo `macattr` -> `macaddr`
