### PR TITLE
updated for focal/noetic/python3 compatibility

### DIFF
--- a/nodes/ddwrt.py
+++ b/nodes/ddwrt.py
@@ -119,7 +119,7 @@ class WifiAP:
       line = lines[1].strip()
       iparts = line.split(":", 1)
       parts = iparts[1].split()
-      print interface, parts
+      print (interface, parts)
       
 
   def fetchCurrentAP(self):
@@ -228,13 +228,13 @@ def test():
   while 1:
     if 0:
       survey = ap.fetchSiteSurvey()
-      print survey
+      print (survey)
     if 1:
       node = ap.fetchCurrentAP()
-      print node
+      print (node)
 
 def usage(progname):
-  print __doc__ % vars()
+  print (__doc__ % vars())
 
 def main(argv, stdout, environ):
   progname = argv[0]

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>wifi_ddwrt</name>
   <version>0.2.0</version>
   <description>Access to the DD-WRT wifi</description>
@@ -15,16 +15,17 @@
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>message_runtime</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>tf</run_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>tf</exec_depend>
 
-  <run_depend>std_msgs</run_depend>>
-  <run_depend>pr2_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
+  <exec_depend>std_msgs</exec_depend>>
+  <exec_depend>pr2_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
 
-  <run_depend>python-mechanize</run_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-mechanize</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-mechanize</exec_depend>
 
 </package>


### PR DESCRIPTION
upgraded to package format 3, python3 compatibility, passes prerelease tests on noetic/focal:

generate_prerelease_script.py   https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml   noetic default ubuntu focal amd64   --custom-repo     wifi_ddrwt__custom-1:git:https://github.com/PR2-prime/wifi_ddwrt.git:noetic-devel   --level 1   --output-dir ./
